### PR TITLE
Improve Application Versioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,11 @@ DEFAULT: build
 GO           ?= go
 GOFMT        ?= $(GO)fmt
 APP          := talaria
+DOCKER_ORG   := xmidt
 FIRST_GOPATH := $(firstword $(subst :, ,$(shell $(GO) env GOPATH)))
 BINARY    := $(FIRST_GOPATH)/bin/$(APP)
 
-PROGVER = $(shell grep 'applicationVersion.*= ' main.go | awk '{print $$3}' | sed -e 's/\"//g')
+PROGVER = $(shell git describe --tags `git rev-list --tags --max-count=1` | tail -1 | sed 's/v\(.*\)/\1/')
 
 .PHONY: go-mod-vendor
 go-mod-vendor:
@@ -49,23 +50,22 @@ update-version:
 
 .PHONY: install
 install: go-mod-vendor
-	echo $(GO) build -o $(BINARY) $(PROGVER)
+	go install -ldflags "-X 'main.BuildTime=`date -u '+%Y-%m-%d %H:%M:%S'`' -X main.GitCommit=`git rev-parse --short HEAD` -X main.Version=$(PROGVER)"
 
 .PHONY: release-artifacts
 release-artifacts: go-mod-vendor
 	mkdir -p ./.ignore
-	GOOS=darwin GOARCH=amd64 $(GO) build -o ./.ignore/$(APP)-$(PROGVER).darwin-amd64
-	GOOS=linux  GOARCH=amd64 $(GO) build -o ./.ignore/$(APP)-$(PROGVER).linux-amd64
+	GOOS=darwin GOARCH=amd64 $(GO) build -ldflags "-X 'main.BuildTime=`date -u '+%Y-%m-%d %H:%M:%S'`' -X main.GitCommit=`git rev-parse --short HEAD` -X main.Version=$(PROGVER)" -o ./.ignore/$(APP)-$(PROGVER).darwin-amd64
+	GOOS=linux  GOARCH=amd64 $(GO) build -ldflags "-X 'main.BuildTime=`date -u '+%Y-%m-%d %H:%M:%S'`' -X main.GitCommit=`git rev-parse --short HEAD` -X main.Version=$(PROGVER)" -o ./.ignore/$(APP)-$(PROGVER).linux-amd64
 
 .PHONY: docker
 docker:
-	docker build -f ./deploy/Dockerfile -t $(APP):$(PROGVER) .
+	docker build --build-arg VERSION=$(PROGVER) -f ./deploy/Dockerfile -t $(DOCKER_ORG)/$(APP):$(PROGVER) .
 
 # build docker without running modules
 .PHONY: local-docker
 local-docker:
-	GOOS=linux  GOARCH=amd64 $(GO) build -o $(APP)_linux_amd64
-	docker build -f ./deploy/Dockerfile.local -t $(APP):local .
+	docker build --build-arg VERSION=$(PROGVER)+local -f ./deploy/Dockerfile.local -t $(DOCKER_ORG)/$(APP):local .
 
 .PHONY: style
 style:

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -2,12 +2,13 @@ FROM golang:alpine as builder
 MAINTAINER Jack Murdock <jack_murdock@comcast.com>
 
 WORKDIR /go/src/github.com/xmidt-org/talaria
+ARG VERSION=undefined
 
 RUN apk update && apk upgrade && \
     apk add --no-cache bash git openssh
 
 COPY . .
-RUN GO111MODULE=on go build -o talaria_linux_amd64
+RUN GO111MODULE=on go build -ldflags "-X 'main.BuildTime=`date -u '+%Y-%m-%d %H:%M:%S'`' -X main.GitCommit=`git rev-parse --short HEAD` -X main.Version=$VERSION" -o talaria_linux_amd64
 
 FROM alpine
 

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -3,12 +3,14 @@ MAINTAINER Jack Murdock <jack_murdock@comcast.com>
 
 WORKDIR /go/src/github.com/xmidt-org/talaria
 ARG VERSION=undefined
+ARG GITCOMMIT=undefined
+ARG BUILDTIME=undefined
 
 RUN apk update && apk upgrade && \
     apk add --no-cache bash git openssh
 
 COPY . .
-RUN GO111MODULE=on go build -ldflags "-X 'main.BuildTime=`date -u '+%Y-%m-%d %H:%M:%S'`' -X main.GitCommit=`git rev-parse --short HEAD` -X main.Version=$VERSION" -o talaria_linux_amd64
+RUN GO111MODULE=on go build -ldflags "-X 'main.BuildTime=${BUILDTIME}' -X main.GitCommit=${GITCOMMIT} -X main.Version=${VERSION}" -o talaria_linux_amd64
 
 FROM alpine
 

--- a/deploy/Dockerfile.local
+++ b/deploy/Dockerfile.local
@@ -2,12 +2,13 @@ FROM golang:alpine as builder
 MAINTAINER Jack Murdock <jack_murdock@comcast.com>
 
 WORKDIR /go/src/github.com/xmidt-org/talaria
+ARG VERSION=undefined
 
 RUN apk add --update git curl
 
 COPY . .
 
-RUN go build -o talaria_linux_amd64
+RUN go build -ldflags "-X 'main.BuildTime=`date -u '+%Y-%m-%d %H:%M:%S'`' -X main.GitCommit=`git rev-parse --short HEAD` -X main.Version=$VERSION" -o talaria_linux_amd64
 
 FROM alpine
 

--- a/deploy/Dockerfile.local
+++ b/deploy/Dockerfile.local
@@ -3,12 +3,14 @@ MAINTAINER Jack Murdock <jack_murdock@comcast.com>
 
 WORKDIR /go/src/github.com/xmidt-org/talaria
 ARG VERSION=undefined
+ARG GITCOMMIT=undefined
+ARG BUILDTIME=undefined
 
 RUN apk add --update git curl
 
 COPY . .
 
-RUN go build -ldflags "-X 'main.BuildTime=`date -u '+%Y-%m-%d %H:%M:%S'`' -X main.GitCommit=`git rev-parse --short HEAD` -X main.Version=$VERSION" -o talaria_linux_amd64
+RUN go build -ldflags "-X 'main.BuildTime=${BUILDTIME}' -X main.GitCommit=${GITCOMMIT} -X main.Version=${VERSION}" -o talaria_linux_amd64
 
 FROM alpine
 

--- a/deploy/packaging/talaria.spec
+++ b/deploy/packaging/talaria.spec
@@ -22,7 +22,7 @@ BuildRequires: golang >= 1.12
 The XMiDT routing agent.
 
 %build
-GO111MODULE=on go build -o $RPM_SOURCE_DIR/%{name} %{_topdir}/..
+GO111MODULE=on go build -ldflags "-X 'main.BuildTime=`date -u '+%Y-%m-%d %H:%M:%S'`' -X main.GitCommit=`git rev-parse --short HEAD` -X main.Version=%{_version}" -o $RPM_SOURCE_DIR/%{name} %{_topdir}/..
 
 %install
 echo rm -rf %{buildroot}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2017 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrintVersionInfo(t *testing.T) {
+	testCases := []struct {
+		name           string
+		expectedOutput []string
+		overrideValues func()
+		lineCount      int
+	}{
+		{
+			"default",
+			[]string{
+				"talaria:",
+				"version: \tundefined",
+				"go version: \tgo",
+				"built time: \tundefined",
+				"git commit: \tundefined",
+				"os/arch: \t",
+			},
+			func() {},
+			6,
+		},
+		{
+			"set values",
+			[]string{
+				"talaria:",
+				"version: \t1.0.0\n",
+				"go version: \tgo",
+				"built time: \tsome time\n",
+				"git commit: \tgit sha\n",
+				"os/arch: \t",
+			},
+			func() {
+				Version = "1.0.0"
+				BuildTime = "some time"
+				GitCommit = "git sha"
+			},
+			6,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resetGlobals()
+			tc.overrideValues()
+			buf := &bytes.Buffer{}
+			printVersionInfo(buf)
+			count := 0
+			for {
+				line, err := buf.ReadString(byte('\n'))
+				if err != nil {
+					break
+				}
+				assert.Contains(t, line, tc.expectedOutput[count])
+				if strings.Contains(line, "\t") {
+					keyAndValue := strings.Split(line, "\t")
+					// The value after the tab should have more than 2 characters
+					// 1) the first character of the value and the new line
+					assert.True(t, len(keyAndValue[1]) > 2)
+				}
+				count++
+			}
+			assert.Equal(t, tc.lineCount, count)
+			resetGlobals()
+		})
+	}
+}
+
+func resetGlobals() {
+	Version = "undefined"
+	BuildTime = "undefined"
+	GitCommit = "undefined"
+}


### PR DESCRIPTION
This will allow for better bug reports and information the binary running.
This information can be retrieved upon providing the -v or --version
flag

Closes #107 

```
docker run --rm xmidt/talaria:0.1.3 --version
talaria:
  version:      0.1.3
  go version:   go1.13.1
  built time:   2019-10-14 15:38:00
  git commit:   8b3c443
  os/arch:      linux/amd64
```