### PR TITLE
Add helm chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,13 @@ coverage.txt
 #Goland
 .idea/
 
+# helm 
+deploy/k8s/talaria/rendered.*
+
 # binaries
 talaria
 .ignore
+
+# keep talaria directory
+!deploy/helm/talaria
+

--- a/README.md
+++ b/README.md
@@ -133,7 +133,10 @@ then replace `local` in the `docker build` command.
 
 ### Kubernetes
 
-WIP. TODO: add info
+A helm chart can be used to deploy talaria to kubernetes
+```
+helm install xmidt-talaria deploy/helm/talaria/
+```
 
 ## Deploy
 

--- a/deploy/helm/talaria/.helmignore
+++ b/deploy/helm/talaria/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/deploy/helm/talaria/Chart.yaml
+++ b/deploy/helm/talaria/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: talaria
+description: A Helm chart to deploy talaria to Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: 1.16.0
+
+dependencies:

--- a/deploy/helm/talaria/rendered.yaml
+++ b/deploy/helm/talaria/rendered.yaml
@@ -1,0 +1,428 @@
+NAME: chart-1571842121
+LAST DEPLOYED: 2019-10-23 16:48:41.991946512 +0200 CEST m=+0.710887202
+NAMESPACE: realtimedata-xmidt-cloud
+STATUS: pending-install
+MANIFEST:
+---
+# Source: talaria/templates/talaria.yaml
+apiVersion: v1
+data:
+  talaria.yaml: |
+  # The unique fully-qualified-domain-name of the server.  It is provided to
+  # the X-Talaria-Server header for showing what server fulfilled the request
+  # sent.
+  # (Optional)
+  server: "talaria"
+
+  ########################################
+  #   Labeling/Tracing via HTTP Headers Configuration
+  ########################################
+
+  # Provides this build number to the X-Talaria-Build header for
+  # showing machine version information.  The build number SHOULD
+  # match the scheme `version-build` but there is not a strict requirement.
+  # (Optional)
+  build: "0.1.4"
+
+  # Provides the region information to the X-Talaria-Region header
+  # for showing what region this machine is located in.  The region
+  # is arbitrary and optional.
+  # (Optional)
+  region: "east"
+
+  # Provides the flavor information to the X-Talaria-Flavor header
+  # for showing what flavor this machine is associated with.  The flavor
+  # is arbitrary and optional.
+  # (Optional)
+  flavor: "mint"
+
+  ##############################################################################
+  # WebPA Service configuration
+  ##############################################################################
+
+  # For a complete view of the service config structure,
+  # checkout https://godoc.org/github.com/xmidt-org/webpa-common/server#WebPA
+
+  ########################################
+  #   primary endpoint Configuration
+  ########################################
+
+  # primary defines the details needed for the primary endpoint.  The
+  # primary endpoint accepts the events from talaria (typically).
+  # define https://godoc.org/github.com/xmidt-org/webpa-common/server#Basic
+  primary:
+    # address provides the port number for the endpoint to bind to.
+    # ":443" is ideal, but may require some special handling due to it being
+    # a reserved (by the kernel) port.
+    address: ":6200"
+    # HTTPS/TLS
+    #
+    # certificateFile provides the public key and CA chain in PEM format if
+    # TLS is used.  Note: the certificate needs to match the fqdn for clients
+    # to accept without issue.
+    #
+    # keyFile provides the private key that matches the certificateFile
+    # (Optional)
+    # certificateFile: "/etc/talaria/public.pem"
+    # keyFile: "/etc/talaria/private.pem"
+  ########################################
+  #   health endpoint Configuration
+  ########################################
+
+  # health defines the details needed for the health check endpoint.  The
+  # health check endpoint is generally used by services (like AWS Route53
+  # or consul) to determine if this particular machine is healthy or not.
+  # define https://godoc.org/github.com/xmidt-org/webpa-common/server#Health
+  health:
+    # address provides the port number for the endpoint to bind to.
+    # ":80" is ideal, but may require some special handling due to it being
+    # a reserved (by the kernel) port.
+    address: ":6201"
+
+    # logInterval appears to be present from before we had formal metrics
+    # (Deprecated)
+    # logInterval: "60s"
+    # options appears to be present from before we had formal metrics
+    # (Deprecated)
+    # options:
+    #  - "PayloadsOverZero"
+    #  - "PayloadsOverHundred"
+    #  - "PayloadsOverThousand"
+    #  - "PayloadsOverTenThousand"
+
+  ########################################
+  #   Debugging/pprof Configuration
+  ########################################
+
+  # pprof defines the details needed for the pprof debug endpoint.
+  # define https://godoc.org/github.com/xmidt-org/webpa-common/server#Basic
+  # (Optional)
+  pprof:
+    # address provides the port number for the endpoint to bind to.
+    address: ":6202"
+
+  ########################################
+  #   Control Configuration
+  ########################################
+
+  # control configures the details needed for the control server.
+  # defined https://godoc.org/github.com/xmidt-org/webpa-common/xhttp#ServerOptions
+  control:
+    # address provides the port number for the endpoint to bind to.
+    # defaults to the internal net/http default
+    address: ":6203"
+
+  ########################################
+  #   Metrics Configuration
+  ########################################
+
+  # metric defines the details needed for the prometheus metrics endpoint
+  # define https://godoc.org/github.com/xmidt-org/webpa-common/server#Metric
+  # (Optional)
+  metric:
+    # address provides the port number for the endpoint to bind to.  Port 6204
+    # was chosen because it does not conflict with any of the other prometheus
+    # metrics or other machines in the xmidt cluster.  You may use any port you
+    # wish.
+    address: ":6204"
+
+    # metricsOptions provides the details needed to configure the prometheus
+    # metric data.  Metrics generally have the form:
+    #
+    # {namespace}_{subsystem}_{metric}
+    #
+    # so if you use the suggested value below, your metrics are prefixed like
+    # this:
+    #
+    # xmidt_talaria_{metric}
+    #
+    # (Optional)
+    metricsOptions:
+      # namespace is the namespace of the metrics provided
+      # (Optional)
+      namespace: "xmidt"
+      # subsystem is the subsystem of the metrics provided
+      # (Optional)
+      subsystem: "talaria"
+
+  ########################################
+  #   Logging Related Configuration
+  ########################################
+
+  # log configures the logging subsystem details
+  log:
+    # file is the name of the most recent log file.  If set to "stdout" this
+    # will log to os.Stdout.
+    # (Optional) defaults to os.TempDir()
+    # file: "/var/log/talaria/talaria.log"
+    file: "stdout"
+
+    # level is the logging level to use - INFO, DEBUG, WARN, ERROR
+    # (Optional) defaults to ERROR
+    level: "DEBUG"
+
+    # maxsize is the maximum file size in MB
+    # (Optional) defaults to max 100MB
+    maxsize: 50
+
+    # maxage is the maximum number of days to retain old log files
+    # (Optional) defaults to ignore age limit (0)
+    maxage: 30
+
+    # maxbackups is the maximum number of old log files to retain
+    # (Optional) defaults to retain all (0)
+    maxbackups: 10
+
+    # json is a flag indicating whether JSON logging output should be used.
+    # (Optional) defaults to false
+    json: true
+
+  ########################################
+  #   Device  Related Configuration
+  ########################################
+
+  # device configures the generic talaria configuration.
+  # It has three parts: manager, outbound, and inbound.
+  # The manager section handles the actual device connection configuration.
+  # The outbound section configures the outbound requests to caduceus or some other receiver of messages.
+  # The inbound section configures the api inbound requests.
+  device:
+    # manager handles the device manager related configuration.
+    # defined by https://godoc.org/github.com/xmidt-org/webpa-common/device#Options
+    manager:
+      # upgrader is the gorilla mux websocket configuration, which upgrades an
+      # incoming device connection from http to websocket.
+      # defined by https://godoc.org/github.com/gorilla/websocket#Upgrader
+      upgrader:
+        # handshakeTimeout is the time to wait before rejecting an incoming/new websocket connection.
+        # (Optional) defaults to (0), aka do not timeout
+        handshakeTimeout: "10s"
+
+      # maxDevices is the maximum number of devices allowed to connect to the talaria.
+      # (Optional) defaults to math.MaxUint32
+      maxDevices: 100
+
+      # deviceMessageQueueSize is the capacity of the channel which stores messages waiting
+      # to be transmitted to a device.
+      # (Optional) defaults to 100
+      deviceMessageQueueSize: 1000
+
+      # pingPeriod is the time between pings sent to each device to ensure they
+      # are still reachable.
+      # (Optional) defaults to 45s
+      pingPeriod: "1m"
+
+      # idlePeriod is the length of time a device connection is allowed to be idle,
+      # with no traffic coming from the device.
+      # (Optional) defaults to 45s
+      idlePeriod: "2m"
+
+      # requestTimeout is the timeout for all inbound HTTP requests.
+      # (Optional) defaults to 30s
+      requestTimeout: "15s"
+
+    # outbound handles api request to push messages to a receiver (usually caduceus).
+    # defined by https://github.com/xmidt-org/talaria/blob/master/outbounder.go
+    # TODO: link godoc instead
+    outbound:
+      # method is the http method to use against the receiving server.
+      # (Optional) defaults to POST
+      method: "POST"
+
+      # retries is the number attempts to sent the message to the receiver.
+      # (Optional) defaults to 1
+      retries: 3
+
+      # eventEndpoints is a map defining where to send the events to,
+      # where the key is the device event type (https://godoc.org/github.com/xmidt-org/webpa-common/device#EventType)
+      # and the value is the url.
+      eventEndpoints:
+        default: http://caduceus:6000/api/v3/notify
+
+      # requestTimeout is how long an event will be held on to starting from when it is
+      # received till completing the http request.
+      # So if the event was in the queue for 124s and using the default value
+      # the http request only has 1s to complete before moving on.
+      # (Optional) defaults to 125s
+      requestTimeout: "2m"
+
+      # TODO:// double check if this is correct
+      # defaultScheme is the default scheme for the http request.
+      # (Optional) defaults to https
+      defaultScheme: "https"
+
+      # allowedSchemes is a list of schemes, used in conjunction with the defaultScheme
+      # for the URLFilter.
+      # (Optional) defaults to []string{"https"}
+      allowedSchemes:
+        - "http"
+        - "https"
+
+      # outboundQueueSize is the size of the buffer to queue messages for each
+      # receiver.
+      # (Optional) defaults to 1000
+      outboundQueueSize: 2000
+
+      # workerPoolSize configures how many active go threads send messages to the receivers.
+      # (Optional) defaults to 100
+      workerPoolSize: 50
+
+      # transport is a way to overwrite the default golang http.Transport configuration.
+      # defined  https://golang.org/pkg/net/http/#Transport
+      # (Optional) defaults described below
+      transport:
+        # (Optional) defaults to 0, aka do not limit it
+        maxIdleConns: 0
+        # (Optional) defaults to 100
+        maxIdleConnsPerHost: 100
+        # (Optional) defaults to 0s, aka do not timeout while in idle
+        idleConnTimeout: "120s"
+
+      # clientTimeout specifies a time limit for requests made by this
+      # Client. The timeout includes connection time, any
+      # redirects, and reading the response body. The timer remains
+      # running after Get, Head, Post, or Do return and will
+      # interrupt reading of the Response.Body.
+      # defined  https://golang.org/pkg/net/http/#Client
+      # (Optional) defaults to 160s
+      clientTimeout: "2m"
+
+      # authKey is the basic auth token used for sending messages to the receiver.
+      # (Optional) defaults to no auth token
+      # WARNING: This is an example auth token. DO NOT use this in production.
+      authKey: YXV0aEhlYWRlcg==
+
+  # inbound configures the api inbound requests.
+  # (Optional) defaults described below
+  inbound:
+    # authKey is the basic auth token incoming api requests like /stat, and /devices
+    # (Optional) defaults to no auth token
+    # WARNING: This is an example auth token. DO NOT use this in production.
+    authKey: YXV0aEhlYWRlcg==
+
+  ########################################
+  #   Service Discovery Configuration
+  ########################################
+
+  # service configures the server for service discovery.
+  # defined https://godoc.org/github.com/xmidt-org/webpa-common/service/servicecfg#Options
+  # this is required, consul or fixed must be used.
+  service:
+    # defaultScheme, used for the registered servers for communication.
+    # (Optional) defaults to https
+    defaultScheme: http
+
+    # vnodeCount used for consistent hash calculation github.com/billhathaway/consistentHash.
+    # number of virtual nodes. should be a prime number
+    # it is a tradeoff of memory and ~ log(N) speed versus how well the hash spreads
+    # (Optional) defaults to 211
+    vnodeCount: 211
+
+    # disableFilter disables filtering.
+    # (Deprecated) does not do anything
+    # disableFilter: false
+
+    # fixed is the list of servers in the datacenter.
+    # (Optional) default to empty list
+    fixed:
+      - http://talaria:6200
+kind: ConfigMap
+metadata:
+  labels:
+    app: xmidt-app
+  name: talaria-config
+---
+# Source: talaria/templates/talaria.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+  labels:
+    component: talaria
+    release: talaria
+  name: talaria
+spec:
+  clusterIP: None
+  ports:
+    - name: http0
+      port: 6200
+      protocol: TCP
+    - name: health
+      port: 6201
+      protocol: TCP
+    - name: pprof
+      port: 6202
+      protocol: TCP
+    - name: control
+      port: 6203
+      protocol: TCP
+    - name: metric
+      port: 6204
+      protocol: TCP
+  selector:
+    app: xmidt-app-talaria
+---
+# Source: talaria/templates/talaria.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: talaria
+  labels:
+    app: xmidt-app-talaria
+spec:
+  selector:
+    matchLabels:
+      app: xmidt-app-talaria
+  updateStrategy:
+    type: RollingUpdate
+  replicas: 1
+  serviceName: xmidt-app-talaria
+  template:
+    metadata:
+      labels:
+        app: xmidt-app-talaria
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - xmidt-app-talaria
+      volumes:
+        - name: talaria-config
+          projected:
+            sources:
+              - configMap:
+                  name: talaria-config
+                  items:
+                    - key: talaria.yaml
+                      path: talaria.yaml
+                      mode: 0755
+      securityContext:
+        runAsNonRoot: false
+        runAsUser: 999
+        supplementalGroups: [999]
+      containers:
+        - image: xmidt/talaria
+          name: talaria
+          ports:
+            - containerPort: 6200
+              protocol: TCP
+            - containerPort: 6201
+              protocol: TCP
+            - containerPort: 6202
+              protocol: TCP
+            - containerPort: 6203
+              protocol: TCP
+            - containerPort: 6204
+              protocol: TCP
+          volumeMounts:
+            - name: talaria-config
+              mountPath: "/etc/talaria"
+              readOnly: true
+

--- a/deploy/helm/talaria/templates/talaria.yaml
+++ b/deploy/helm/talaria/templates/talaria.yaml
@@ -1,0 +1,423 @@
+apiVersion: v1
+data:
+  talaria.yaml: |
+  # The unique fully-qualified-domain-name of the server.  It is provided to
+  # the X-Talaria-Server header for showing what server fulfilled the request
+  # sent.
+  # (Optional)
+  server: "talaria"
+
+  ########################################
+  #   Labeling/Tracing via HTTP Headers Configuration
+  ########################################
+
+  # Provides this build number to the X-Talaria-Build header for
+  # showing machine version information.  The build number SHOULD
+  # match the scheme `version-build` but there is not a strict requirement.
+  # (Optional)
+  build: "0.1.4"
+
+  # Provides the region information to the X-Talaria-Region header
+  # for showing what region this machine is located in.  The region
+  # is arbitrary and optional.
+  # (Optional)
+  region: "east"
+
+  # Provides the flavor information to the X-Talaria-Flavor header
+  # for showing what flavor this machine is associated with.  The flavor
+  # is arbitrary and optional.
+  # (Optional)
+  flavor: "mint"
+
+  ##############################################################################
+  # WebPA Service configuration
+  ##############################################################################
+
+  # For a complete view of the service config structure,
+  # checkout https://godoc.org/github.com/xmidt-org/webpa-common/server#WebPA
+
+  ########################################
+  #   primary endpoint Configuration
+  ########################################
+
+  # primary defines the details needed for the primary endpoint.  The
+  # primary endpoint accepts the events from talaria (typically).
+  # define https://godoc.org/github.com/xmidt-org/webpa-common/server#Basic
+  primary:
+    # address provides the port number for the endpoint to bind to.
+    # ":443" is ideal, but may require some special handling due to it being
+    # a reserved (by the kernel) port.
+    address: "{{ .Values.talaria.address.host }}:{{ .Values.talaria.address.port }}"
+    # HTTPS/TLS
+    #
+    # certificateFile provides the public key and CA chain in PEM format if
+    # TLS is used.  Note: the certificate needs to match the fqdn for clients
+    # to accept without issue.
+    #
+    # keyFile provides the private key that matches the certificateFile
+    # (Optional)
+    # certificateFile: "/etc/talaria/public.pem"
+    # keyFile: "/etc/talaria/private.pem"
+  ########################################
+  #   health endpoint Configuration
+  ########################################
+
+  # health defines the details needed for the health check endpoint.  The
+  # health check endpoint is generally used by services (like AWS Route53
+  # or consul) to determine if this particular machine is healthy or not.
+  # define https://godoc.org/github.com/xmidt-org/webpa-common/server#Health
+  health:
+    # address provides the port number for the endpoint to bind to.
+    # ":80" is ideal, but may require some special handling due to it being
+    # a reserved (by the kernel) port.
+    address: "{{ .Values.health.address.host }}:{{ .Values.health.address.port }}"
+
+    # logInterval appears to be present from before we had formal metrics
+    # (Deprecated)
+    # logInterval: "60s"
+    # options appears to be present from before we had formal metrics
+    # (Deprecated)
+    # options:
+    #  - "PayloadsOverZero"
+    #  - "PayloadsOverHundred"
+    #  - "PayloadsOverThousand"
+    #  - "PayloadsOverTenThousand"
+
+  ########################################
+  #   Debugging/pprof Configuration
+  ########################################
+
+  # pprof defines the details needed for the pprof debug endpoint.
+  # define https://godoc.org/github.com/xmidt-org/webpa-common/server#Basic
+  # (Optional)
+  pprof:
+    # address provides the port number for the endpoint to bind to.
+    address: "{{ .Values.pprof.address.host }}:{{ .Values.pprof.address.port }}"
+
+  ########################################
+  #   Control Configuration
+  ########################################
+
+  # control configures the details needed for the control server.
+  # defined https://godoc.org/github.com/xmidt-org/webpa-common/xhttp#ServerOptions
+  control:
+    # address provides the port number for the endpoint to bind to.
+    # defaults to the internal net/http default
+    address: "{{ .Values.control.address.host }}:{{ .Values.control.address.port }}"
+
+  ########################################
+  #   Metrics Configuration
+  ########################################
+
+  # metric defines the details needed for the prometheus metrics endpoint
+  # define https://godoc.org/github.com/xmidt-org/webpa-common/server#Metric
+  # (Optional)
+  metric:
+    # address provides the port number for the endpoint to bind to.  Port 6204
+    # was chosen because it does not conflict with any of the other prometheus
+    # metrics or other machines in the xmidt cluster.  You may use any port you
+    # wish.
+    address: "{{ .Values.metric.address.host }}:{{ .Values.metric.address.port }}"
+
+    # metricsOptions provides the details needed to configure the prometheus
+    # metric data.  Metrics generally have the form:
+    #
+    # {namespace}_{subsystem}_{metric}
+    #
+    # so if you use the suggested value below, your metrics are prefixed like
+    # this:
+    #
+    # xmidt_talaria_{metric}
+    #
+    # (Optional)
+    metricsOptions:
+      # namespace is the namespace of the metrics provided
+      # (Optional)
+      namespace: "xmidt"
+      # subsystem is the subsystem of the metrics provided
+      # (Optional)
+      subsystem: "talaria"
+
+  ########################################
+  #   Logging Related Configuration
+  ########################################
+
+  # log configures the logging subsystem details
+  log:
+    # file is the name of the most recent log file.  If set to "stdout" this
+    # will log to os.Stdout.
+    # (Optional) defaults to os.TempDir()
+    # file: "/var/log/talaria/talaria.log"
+    file: "stdout"
+
+    # level is the logging level to use - INFO, DEBUG, WARN, ERROR
+    # (Optional) defaults to ERROR
+    level: "DEBUG"
+
+    # maxsize is the maximum file size in MB
+    # (Optional) defaults to max 100MB
+    maxsize: 50
+
+    # maxage is the maximum number of days to retain old log files
+    # (Optional) defaults to ignore age limit (0)
+    maxage: 30
+
+    # maxbackups is the maximum number of old log files to retain
+    # (Optional) defaults to retain all (0)
+    maxbackups: 10
+
+    # json is a flag indicating whether JSON logging output should be used.
+    # (Optional) defaults to false
+    json: true
+
+  ########################################
+  #   Device  Related Configuration
+  ########################################
+
+  # device configures the generic talaria configuration.
+  # It has three parts: manager, outbound, and inbound.
+  # The manager section handles the actual device connection configuration.
+  # The outbound section configures the outbound requests to caduceus or some other receiver of messages.
+  # The inbound section configures the api inbound requests.
+  device:
+    # manager handles the device manager related configuration.
+    # defined by https://godoc.org/github.com/xmidt-org/webpa-common/device#Options
+    manager:
+      # upgrader is the gorilla mux websocket configuration, which upgrades an
+      # incoming device connection from http to websocket.
+      # defined by https://godoc.org/github.com/gorilla/websocket#Upgrader
+      upgrader:
+        # handshakeTimeout is the time to wait before rejecting an incoming/new websocket connection.
+        # (Optional) defaults to (0), aka do not timeout
+        handshakeTimeout: "10s"
+
+      # maxDevices is the maximum number of devices allowed to connect to the talaria.
+      # (Optional) defaults to math.MaxUint32
+      maxDevices: 100
+
+      # deviceMessageQueueSize is the capacity of the channel which stores messages waiting
+      # to be transmitted to a device.
+      # (Optional) defaults to 100
+      deviceMessageQueueSize: 1000
+
+      # pingPeriod is the time between pings sent to each device to ensure they
+      # are still reachable.
+      # (Optional) defaults to 45s
+      pingPeriod: "1m"
+
+      # idlePeriod is the length of time a device connection is allowed to be idle,
+      # with no traffic coming from the device.
+      # (Optional) defaults to 45s
+      idlePeriod: "2m"
+
+      # requestTimeout is the timeout for all inbound HTTP requests.
+      # (Optional) defaults to 30s
+      requestTimeout: "15s"
+
+    # outbound handles api request to push messages to a receiver (usually caduceus).
+    # defined by https://github.com/xmidt-org/talaria/blob/master/outbounder.go
+    # TODO: link godoc instead
+    outbound:
+      # method is the http method to use against the receiving server.
+      # (Optional) defaults to POST
+      method: "POST"
+
+      # retries is the number attempts to sent the message to the receiver.
+      # (Optional) defaults to 1
+      retries: 3
+
+      # eventEndpoints is a map defining where to send the events to,
+      # where the key is the device event type (https://godoc.org/github.com/xmidt-org/webpa-common/device#EventType)
+      # and the value is the url.
+      eventEndpoints:
+        default: http://caduceus:6000/api/v3/notify
+
+      # requestTimeout is how long an event will be held on to starting from when it is
+      # received till completing the http request.
+      # So if the event was in the queue for 124s and using the default value
+      # the http request only has 1s to complete before moving on.
+      # (Optional) defaults to 125s
+      requestTimeout: "2m"
+
+      # TODO:// double check if this is correct
+      # defaultScheme is the default scheme for the http request.
+      # (Optional) defaults to https
+      defaultScheme: "https"
+
+      # allowedSchemes is a list of schemes, used in conjunction with the defaultScheme
+      # for the URLFilter.
+      # (Optional) defaults to []string{"https"}
+      allowedSchemes:
+        - "http"
+        - "https"
+
+      # outboundQueueSize is the size of the buffer to queue messages for each
+      # receiver.
+      # (Optional) defaults to 1000
+      outboundQueueSize: 2000
+
+      # workerPoolSize configures how many active go threads send messages to the receivers.
+      # (Optional) defaults to 100
+      workerPoolSize: 50
+
+      # transport is a way to overwrite the default golang http.Transport configuration.
+      # defined  https://golang.org/pkg/net/http/#Transport
+      # (Optional) defaults described below
+      transport:
+        # (Optional) defaults to 0, aka do not limit it
+        maxIdleConns: 0
+        # (Optional) defaults to 100
+        maxIdleConnsPerHost: 100
+        # (Optional) defaults to 0s, aka do not timeout while in idle
+        idleConnTimeout: "120s"
+
+      # clientTimeout specifies a time limit for requests made by this
+      # Client. The timeout includes connection time, any
+      # redirects, and reading the response body. The timer remains
+      # running after Get, Head, Post, or Do return and will
+      # interrupt reading of the Response.Body.
+      # defined  https://golang.org/pkg/net/http/#Client
+      # (Optional) defaults to 160s
+      clientTimeout: "2m"
+
+      # authKey is the basic auth token used for sending messages to the receiver.
+      # (Optional) defaults to no auth token
+      # WARNING: This is an example auth token. DO NOT use this in production.
+      authKey: YXV0aEhlYWRlcg==
+
+  # inbound configures the api inbound requests.
+  # (Optional) defaults described below
+  inbound:
+    # authKey is the basic auth token incoming api requests like /stat, and /devices
+    # (Optional) defaults to no auth token
+    # WARNING: This is an example auth token. DO NOT use this in production.
+    authKey: YXV0aEhlYWRlcg==
+
+  ########################################
+  #   Service Discovery Configuration
+  ########################################
+
+  # service configures the server for service discovery.
+  # defined https://godoc.org/github.com/xmidt-org/webpa-common/service/servicecfg#Options
+  # this is required, consul or fixed must be used.
+  service:
+    # defaultScheme, used for the registered servers for communication.
+    # (Optional) defaults to https
+    defaultScheme: http
+
+    # vnodeCount used for consistent hash calculation github.com/billhathaway/consistentHash.
+    # number of virtual nodes. should be a prime number
+    # it is a tradeoff of memory and ~ log(N) speed versus how well the hash spreads
+    # (Optional) defaults to 211
+    vnodeCount: 211
+
+    # disableFilter disables filtering.
+    # (Deprecated) does not do anything
+    # disableFilter: false
+
+    # fixed is the list of servers in the datacenter.
+    # (Optional) default to empty list
+    fixed:
+      - http://talaria:{{ .Values.talaria.address.port }}
+kind: ConfigMap
+metadata:
+  labels:
+    app: xmidt-app
+  name: talaria-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+  labels:
+    component: talaria
+    release: talaria
+  name: talaria
+spec:
+  clusterIP: None
+  ports:
+    - name: http0
+      port: {{ .Values.talaria.address.port }}
+      protocol: TCP
+    - name: health
+      port: {{ .Values.health.address.port }}
+      protocol: TCP
+    - name: pprof
+      port: {{ .Values.pprof.address.port }}
+      protocol: TCP
+    - name: control
+      port: {{ .Values.control.address.port }}
+      protocol: TCP
+    - name: metric
+      port: {{ .Values.metric.address.port }}
+      protocol: TCP
+  selector:
+    app: xmidt-app-talaria
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: talaria
+  labels:
+    app: xmidt-app-talaria
+spec:
+  selector:
+    matchLabels:
+      app: xmidt-app-talaria
+  updateStrategy:
+    type: RollingUpdate
+  replicas: 1
+  serviceName: xmidt-app-talaria
+  template:
+    metadata:
+      labels:
+        app: xmidt-app-talaria
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - xmidt-app-talaria
+      volumes:
+        - name: talaria-config
+          projected:
+            sources:
+              - configMap:
+                  name: talaria-config
+                  items:
+                    - key: talaria.yaml
+                      path: talaria.yaml
+                      mode: 0755
+      securityContext:
+        runAsNonRoot: false
+        runAsUser: 999
+        supplementalGroups: [999]
+      containers:
+        - image: {{ .Values.talaria.image }}
+          name: talaria
+          ports:
+            - containerPort: {{ .Values.talaria.address.port }}
+              protocol: TCP
+            - containerPort: {{ .Values.health.address.port }}
+              protocol: TCP
+            - containerPort: {{ .Values.pprof.address.port }}
+              protocol: TCP
+            - containerPort: {{ .Values.control.address.port }}
+              protocol: TCP
+            - containerPort: {{ .Values.metric.address.port }}
+              protocol: TCP
+          volumeMounts:
+            - name: talaria-config
+              mountPath: "/etc/talaria"
+              readOnly: true
+      {{ if (.Values.imagePullSecretName) }}
+      imagePullSecrets:
+        - name: {{ .Values.imagePullSecretName }}}
+      {{ end }}
+      

--- a/deploy/helm/talaria/templates/talaria.yaml
+++ b/deploy/helm/talaria/templates/talaria.yaml
@@ -1,324 +1,324 @@
 apiVersion: v1
 data:
   talaria.yaml: |
-  # The unique fully-qualified-domain-name of the server.  It is provided to
-  # the X-Talaria-Server header for showing what server fulfilled the request
-  # sent.
-  # (Optional)
-  server: "talaria"
-
-  ########################################
-  #   Labeling/Tracing via HTTP Headers Configuration
-  ########################################
-
-  # Provides this build number to the X-Talaria-Build header for
-  # showing machine version information.  The build number SHOULD
-  # match the scheme `version-build` but there is not a strict requirement.
-  # (Optional)
-  build: "0.1.4"
-
-  # Provides the region information to the X-Talaria-Region header
-  # for showing what region this machine is located in.  The region
-  # is arbitrary and optional.
-  # (Optional)
-  region: "east"
-
-  # Provides the flavor information to the X-Talaria-Flavor header
-  # for showing what flavor this machine is associated with.  The flavor
-  # is arbitrary and optional.
-  # (Optional)
-  flavor: "mint"
-
-  ##############################################################################
-  # WebPA Service configuration
-  ##############################################################################
-
-  # For a complete view of the service config structure,
-  # checkout https://godoc.org/github.com/xmidt-org/webpa-common/server#WebPA
-
-  ########################################
-  #   primary endpoint Configuration
-  ########################################
-
-  # primary defines the details needed for the primary endpoint.  The
-  # primary endpoint accepts the events from talaria (typically).
-  # define https://godoc.org/github.com/xmidt-org/webpa-common/server#Basic
-  primary:
-    # address provides the port number for the endpoint to bind to.
-    # ":443" is ideal, but may require some special handling due to it being
-    # a reserved (by the kernel) port.
-    address: "{{ .Values.talaria.address.host }}:{{ .Values.talaria.address.port }}"
-    # HTTPS/TLS
-    #
-    # certificateFile provides the public key and CA chain in PEM format if
-    # TLS is used.  Note: the certificate needs to match the fqdn for clients
-    # to accept without issue.
-    #
-    # keyFile provides the private key that matches the certificateFile
+    # The unique fully-qualified-domain-name of the server.  It is provided to
+    # the X-Talaria-Server header for showing what server fulfilled the request
+    # sent.
     # (Optional)
-    # certificateFile: "/etc/talaria/public.pem"
-    # keyFile: "/etc/talaria/private.pem"
-  ########################################
-  #   health endpoint Configuration
-  ########################################
+    server: "talaria"
 
-  # health defines the details needed for the health check endpoint.  The
-  # health check endpoint is generally used by services (like AWS Route53
-  # or consul) to determine if this particular machine is healthy or not.
-  # define https://godoc.org/github.com/xmidt-org/webpa-common/server#Health
-  health:
-    # address provides the port number for the endpoint to bind to.
-    # ":80" is ideal, but may require some special handling due to it being
-    # a reserved (by the kernel) port.
-    address: "{{ .Values.health.address.host }}:{{ .Values.health.address.port }}"
+    ########################################
+    #   Labeling/Tracing via HTTP Headers Configuration
+    ########################################
 
-    # logInterval appears to be present from before we had formal metrics
-    # (Deprecated)
-    # logInterval: "60s"
-    # options appears to be present from before we had formal metrics
-    # (Deprecated)
-    # options:
-    #  - "PayloadsOverZero"
-    #  - "PayloadsOverHundred"
-    #  - "PayloadsOverThousand"
-    #  - "PayloadsOverTenThousand"
-
-  ########################################
-  #   Debugging/pprof Configuration
-  ########################################
-
-  # pprof defines the details needed for the pprof debug endpoint.
-  # define https://godoc.org/github.com/xmidt-org/webpa-common/server#Basic
-  # (Optional)
-  pprof:
-    # address provides the port number for the endpoint to bind to.
-    address: "{{ .Values.pprof.address.host }}:{{ .Values.pprof.address.port }}"
-
-  ########################################
-  #   Control Configuration
-  ########################################
-
-  # control configures the details needed for the control server.
-  # defined https://godoc.org/github.com/xmidt-org/webpa-common/xhttp#ServerOptions
-  control:
-    # address provides the port number for the endpoint to bind to.
-    # defaults to the internal net/http default
-    address: "{{ .Values.control.address.host }}:{{ .Values.control.address.port }}"
-
-  ########################################
-  #   Metrics Configuration
-  ########################################
-
-  # metric defines the details needed for the prometheus metrics endpoint
-  # define https://godoc.org/github.com/xmidt-org/webpa-common/server#Metric
-  # (Optional)
-  metric:
-    # address provides the port number for the endpoint to bind to.  Port 6204
-    # was chosen because it does not conflict with any of the other prometheus
-    # metrics or other machines in the xmidt cluster.  You may use any port you
-    # wish.
-    address: "{{ .Values.metric.address.host }}:{{ .Values.metric.address.port }}"
-
-    # metricsOptions provides the details needed to configure the prometheus
-    # metric data.  Metrics generally have the form:
-    #
-    # {namespace}_{subsystem}_{metric}
-    #
-    # so if you use the suggested value below, your metrics are prefixed like
-    # this:
-    #
-    # xmidt_talaria_{metric}
-    #
+    # Provides this build number to the X-Talaria-Build header for
+    # showing machine version information.  The build number SHOULD
+    # match the scheme `version-build` but there is not a strict requirement.
     # (Optional)
-    metricsOptions:
-      # namespace is the namespace of the metrics provided
+    build: "0.1.4"
+
+    # Provides the region information to the X-Talaria-Region header
+    # for showing what region this machine is located in.  The region
+    # is arbitrary and optional.
+    # (Optional)
+    region: "east"
+
+    # Provides the flavor information to the X-Talaria-Flavor header
+    # for showing what flavor this machine is associated with.  The flavor
+    # is arbitrary and optional.
+    # (Optional)
+    flavor: "mint"
+
+    ##############################################################################
+    # WebPA Service configuration
+    ##############################################################################
+
+    # For a complete view of the service config structure,
+    # checkout https://godoc.org/github.com/xmidt-org/webpa-common/server#WebPA
+
+    ########################################
+    #   primary endpoint Configuration
+    ########################################
+
+    # primary defines the details needed for the primary endpoint.  The
+    # primary endpoint accepts the events from talaria (typically).
+    # define https://godoc.org/github.com/xmidt-org/webpa-common/server#Basic
+    primary:
+      # address provides the port number for the endpoint to bind to.
+      # ":443" is ideal, but may require some special handling due to it being
+      # a reserved (by the kernel) port.
+      address: "{{ .Values.talaria.address.host }}:{{ .Values.talaria.address.port }}"
+      # HTTPS/TLS
+      #
+      # certificateFile provides the public key and CA chain in PEM format if
+      # TLS is used.  Note: the certificate needs to match the fqdn for clients
+      # to accept without issue.
+      #
+      # keyFile provides the private key that matches the certificateFile
       # (Optional)
-      namespace: "xmidt"
-      # subsystem is the subsystem of the metrics provided
+      # certificateFile: "/etc/talaria/public.pem"
+      # keyFile: "/etc/talaria/private.pem"
+    ########################################
+    #   health endpoint Configuration
+    ########################################
+
+    # health defines the details needed for the health check endpoint.  The
+    # health check endpoint is generally used by services (like AWS Route53
+    # or consul) to determine if this particular machine is healthy or not.
+    # define https://godoc.org/github.com/xmidt-org/webpa-common/server#Health
+    health:
+      # address provides the port number for the endpoint to bind to.
+      # ":80" is ideal, but may require some special handling due to it being
+      # a reserved (by the kernel) port.
+      address: "{{ .Values.health.address.host }}:{{ .Values.health.address.port }}"
+
+      # logInterval appears to be present from before we had formal metrics
+      # (Deprecated)
+      # logInterval: "60s"
+      # options appears to be present from before we had formal metrics
+      # (Deprecated)
+      # options:
+      #  - "PayloadsOverZero"
+      #  - "PayloadsOverHundred"
+      #  - "PayloadsOverThousand"
+      #  - "PayloadsOverTenThousand"
+
+    ########################################
+    #   Debugging/pprof Configuration
+    ########################################
+
+    # pprof defines the details needed for the pprof debug endpoint.
+    # define https://godoc.org/github.com/xmidt-org/webpa-common/server#Basic
+    # (Optional)
+    pprof:
+      # address provides the port number for the endpoint to bind to.
+      address: "{{ .Values.pprof.address.host }}:{{ .Values.pprof.address.port }}"
+
+    ########################################
+    #   Control Configuration
+    ########################################
+
+    # control configures the details needed for the control server.
+    # defined https://godoc.org/github.com/xmidt-org/webpa-common/xhttp#ServerOptions
+    control:
+      # address provides the port number for the endpoint to bind to.
+      # defaults to the internal net/http default
+      address: "{{ .Values.control.address.host }}:{{ .Values.control.address.port }}"
+
+    ########################################
+    #   Metrics Configuration
+    ########################################
+
+    # metric defines the details needed for the prometheus metrics endpoint
+    # define https://godoc.org/github.com/xmidt-org/webpa-common/server#Metric
+    # (Optional)
+    metric:
+      # address provides the port number for the endpoint to bind to.  Port 6204
+      # was chosen because it does not conflict with any of the other prometheus
+      # metrics or other machines in the xmidt cluster.  You may use any port you
+      # wish.
+      address: "{{ .Values.metric.address.host }}:{{ .Values.metric.address.port }}"
+
+      # metricsOptions provides the details needed to configure the prometheus
+      # metric data.  Metrics generally have the form:
+      #
+      # {namespace}_{subsystem}_{metric}
+      #
+      # so if you use the suggested value below, your metrics are prefixed like
+      # this:
+      #
+      # xmidt_talaria_{metric}
+      #
       # (Optional)
-      subsystem: "talaria"
+      metricsOptions:
+        # namespace is the namespace of the metrics provided
+        # (Optional)
+        namespace: "xmidt"
+        # subsystem is the subsystem of the metrics provided
+        # (Optional)
+        subsystem: "talaria"
 
-  ########################################
-  #   Logging Related Configuration
-  ########################################
+    ########################################
+    #   Logging Related Configuration
+    ########################################
 
-  # log configures the logging subsystem details
-  log:
-    # file is the name of the most recent log file.  If set to "stdout" this
-    # will log to os.Stdout.
-    # (Optional) defaults to os.TempDir()
-    # file: "/var/log/talaria/talaria.log"
-    file: "stdout"
+    # log configures the logging subsystem details
+    log:
+      # file is the name of the most recent log file.  If set to "stdout" this
+      # will log to os.Stdout.
+      # (Optional) defaults to os.TempDir()
+      # file: "/var/log/talaria/talaria.log"
+      file: "stdout"
 
-    # level is the logging level to use - INFO, DEBUG, WARN, ERROR
-    # (Optional) defaults to ERROR
-    level: "DEBUG"
+      # level is the logging level to use - INFO, DEBUG, WARN, ERROR
+      # (Optional) defaults to ERROR
+      level: "DEBUG"
 
-    # maxsize is the maximum file size in MB
-    # (Optional) defaults to max 100MB
-    maxsize: 50
+      # maxsize is the maximum file size in MB
+      # (Optional) defaults to max 100MB
+      maxsize: 50
 
-    # maxage is the maximum number of days to retain old log files
-    # (Optional) defaults to ignore age limit (0)
-    maxage: 30
+      # maxage is the maximum number of days to retain old log files
+      # (Optional) defaults to ignore age limit (0)
+      maxage: 30
 
-    # maxbackups is the maximum number of old log files to retain
-    # (Optional) defaults to retain all (0)
-    maxbackups: 10
+      # maxbackups is the maximum number of old log files to retain
+      # (Optional) defaults to retain all (0)
+      maxbackups: 10
 
-    # json is a flag indicating whether JSON logging output should be used.
-    # (Optional) defaults to false
-    json: true
+      # json is a flag indicating whether JSON logging output should be used.
+      # (Optional) defaults to false
+      json: true
 
-  ########################################
-  #   Device  Related Configuration
-  ########################################
+    ########################################
+    #   Device  Related Configuration
+    ########################################
 
-  # device configures the generic talaria configuration.
-  # It has three parts: manager, outbound, and inbound.
-  # The manager section handles the actual device connection configuration.
-  # The outbound section configures the outbound requests to caduceus or some other receiver of messages.
-  # The inbound section configures the api inbound requests.
-  device:
-    # manager handles the device manager related configuration.
-    # defined by https://godoc.org/github.com/xmidt-org/webpa-common/device#Options
-    manager:
-      # upgrader is the gorilla mux websocket configuration, which upgrades an
-      # incoming device connection from http to websocket.
-      # defined by https://godoc.org/github.com/gorilla/websocket#Upgrader
-      upgrader:
-        # handshakeTimeout is the time to wait before rejecting an incoming/new websocket connection.
-        # (Optional) defaults to (0), aka do not timeout
-        handshakeTimeout: "10s"
+    # device configures the generic talaria configuration.
+    # It has three parts: manager, outbound, and inbound.
+    # The manager section handles the actual device connection configuration.
+    # The outbound section configures the outbound requests to caduceus or some other receiver of messages.
+    # The inbound section configures the api inbound requests.
+    device:
+      # manager handles the device manager related configuration.
+      # defined by https://godoc.org/github.com/xmidt-org/webpa-common/device#Options
+      manager:
+        # upgrader is the gorilla mux websocket configuration, which upgrades an
+        # incoming device connection from http to websocket.
+        # defined by https://godoc.org/github.com/gorilla/websocket#Upgrader
+        upgrader:
+          # handshakeTimeout is the time to wait before rejecting an incoming/new websocket connection.
+          # (Optional) defaults to (0), aka do not timeout
+          handshakeTimeout: "10s"
 
-      # maxDevices is the maximum number of devices allowed to connect to the talaria.
-      # (Optional) defaults to math.MaxUint32
-      maxDevices: 100
+        # maxDevices is the maximum number of devices allowed to connect to the talaria.
+        # (Optional) defaults to math.MaxUint32
+        maxDevices: 100
 
-      # deviceMessageQueueSize is the capacity of the channel which stores messages waiting
-      # to be transmitted to a device.
-      # (Optional) defaults to 100
-      deviceMessageQueueSize: 1000
-
-      # pingPeriod is the time between pings sent to each device to ensure they
-      # are still reachable.
-      # (Optional) defaults to 45s
-      pingPeriod: "1m"
-
-      # idlePeriod is the length of time a device connection is allowed to be idle,
-      # with no traffic coming from the device.
-      # (Optional) defaults to 45s
-      idlePeriod: "2m"
-
-      # requestTimeout is the timeout for all inbound HTTP requests.
-      # (Optional) defaults to 30s
-      requestTimeout: "15s"
-
-    # outbound handles api request to push messages to a receiver (usually caduceus).
-    # defined by https://github.com/xmidt-org/talaria/blob/master/outbounder.go
-    # TODO: link godoc instead
-    outbound:
-      # method is the http method to use against the receiving server.
-      # (Optional) defaults to POST
-      method: "POST"
-
-      # retries is the number attempts to sent the message to the receiver.
-      # (Optional) defaults to 1
-      retries: 3
-
-      # eventEndpoints is a map defining where to send the events to,
-      # where the key is the device event type (https://godoc.org/github.com/xmidt-org/webpa-common/device#EventType)
-      # and the value is the url.
-      eventEndpoints:
-        default: http://caduceus:6000/api/v3/notify
-
-      # requestTimeout is how long an event will be held on to starting from when it is
-      # received till completing the http request.
-      # So if the event was in the queue for 124s and using the default value
-      # the http request only has 1s to complete before moving on.
-      # (Optional) defaults to 125s
-      requestTimeout: "2m"
-
-      # TODO:// double check if this is correct
-      # defaultScheme is the default scheme for the http request.
-      # (Optional) defaults to https
-      defaultScheme: "https"
-
-      # allowedSchemes is a list of schemes, used in conjunction with the defaultScheme
-      # for the URLFilter.
-      # (Optional) defaults to []string{"https"}
-      allowedSchemes:
-        - "http"
-        - "https"
-
-      # outboundQueueSize is the size of the buffer to queue messages for each
-      # receiver.
-      # (Optional) defaults to 1000
-      outboundQueueSize: 2000
-
-      # workerPoolSize configures how many active go threads send messages to the receivers.
-      # (Optional) defaults to 100
-      workerPoolSize: 50
-
-      # transport is a way to overwrite the default golang http.Transport configuration.
-      # defined  https://golang.org/pkg/net/http/#Transport
-      # (Optional) defaults described below
-      transport:
-        # (Optional) defaults to 0, aka do not limit it
-        maxIdleConns: 0
+        # deviceMessageQueueSize is the capacity of the channel which stores messages waiting
+        # to be transmitted to a device.
         # (Optional) defaults to 100
-        maxIdleConnsPerHost: 100
-        # (Optional) defaults to 0s, aka do not timeout while in idle
-        idleConnTimeout: "120s"
+        deviceMessageQueueSize: 1000
 
-      # clientTimeout specifies a time limit for requests made by this
-      # Client. The timeout includes connection time, any
-      # redirects, and reading the response body. The timer remains
-      # running after Get, Head, Post, or Do return and will
-      # interrupt reading of the Response.Body.
-      # defined  https://golang.org/pkg/net/http/#Client
-      # (Optional) defaults to 160s
-      clientTimeout: "2m"
+        # pingPeriod is the time between pings sent to each device to ensure they
+        # are still reachable.
+        # (Optional) defaults to 45s
+        pingPeriod: "1m"
 
-      # authKey is the basic auth token used for sending messages to the receiver.
+        # idlePeriod is the length of time a device connection is allowed to be idle,
+        # with no traffic coming from the device.
+        # (Optional) defaults to 45s
+        idlePeriod: "2m"
+
+        # requestTimeout is the timeout for all inbound HTTP requests.
+        # (Optional) defaults to 30s
+        requestTimeout: "15s"
+
+      # outbound handles api request to push messages to a receiver (usually caduceus).
+      # defined by https://github.com/xmidt-org/talaria/blob/master/outbounder.go
+      # TODO: link godoc instead
+      outbound:
+        # method is the http method to use against the receiving server.
+        # (Optional) defaults to POST
+        method: "POST"
+
+        # retries is the number attempts to sent the message to the receiver.
+        # (Optional) defaults to 1
+        retries: 3
+
+        # eventEndpoints is a map defining where to send the events to,
+        # where the key is the device event type (https://godoc.org/github.com/xmidt-org/webpa-common/device#EventType)
+        # and the value is the url.
+        eventEndpoints:
+          default: http://caduceus:6000/api/v3/notify
+
+        # requestTimeout is how long an event will be held on to starting from when it is
+        # received till completing the http request.
+        # So if the event was in the queue for 124s and using the default value
+        # the http request only has 1s to complete before moving on.
+        # (Optional) defaults to 125s
+        requestTimeout: "2m"
+
+        # TODO:// double check if this is correct
+        # defaultScheme is the default scheme for the http request.
+        # (Optional) defaults to https
+        defaultScheme: "https"
+
+        # allowedSchemes is a list of schemes, used in conjunction with the defaultScheme
+        # for the URLFilter.
+        # (Optional) defaults to []string{"https"}
+        allowedSchemes:
+          - "http"
+          - "https"
+
+        # outboundQueueSize is the size of the buffer to queue messages for each
+        # receiver.
+        # (Optional) defaults to 1000
+        outboundQueueSize: 2000
+
+        # workerPoolSize configures how many active go threads send messages to the receivers.
+        # (Optional) defaults to 100
+        workerPoolSize: 50
+
+        # transport is a way to overwrite the default golang http.Transport configuration.
+        # defined  https://golang.org/pkg/net/http/#Transport
+        # (Optional) defaults described below
+        transport:
+          # (Optional) defaults to 0, aka do not limit it
+          maxIdleConns: 0
+          # (Optional) defaults to 100
+          maxIdleConnsPerHost: 100
+          # (Optional) defaults to 0s, aka do not timeout while in idle
+          idleConnTimeout: "120s"
+
+        # clientTimeout specifies a time limit for requests made by this
+        # Client. The timeout includes connection time, any
+        # redirects, and reading the response body. The timer remains
+        # running after Get, Head, Post, or Do return and will
+        # interrupt reading of the Response.Body.
+        # defined  https://golang.org/pkg/net/http/#Client
+        # (Optional) defaults to 160s
+        clientTimeout: "2m"
+
+        # authKey is the basic auth token used for sending messages to the receiver.
+        # (Optional) defaults to no auth token
+        # WARNING: This is an example auth token. DO NOT use this in production.
+        authKey: YXV0aEhlYWRlcg==
+
+    # inbound configures the api inbound requests.
+    # (Optional) defaults described below
+    inbound:
+      # authKey is the basic auth token incoming api requests like /stat, and /devices
       # (Optional) defaults to no auth token
       # WARNING: This is an example auth token. DO NOT use this in production.
       authKey: YXV0aEhlYWRlcg==
 
-  # inbound configures the api inbound requests.
-  # (Optional) defaults described below
-  inbound:
-    # authKey is the basic auth token incoming api requests like /stat, and /devices
-    # (Optional) defaults to no auth token
-    # WARNING: This is an example auth token. DO NOT use this in production.
-    authKey: YXV0aEhlYWRlcg==
+    ########################################
+    #   Service Discovery Configuration
+    ########################################
 
-  ########################################
-  #   Service Discovery Configuration
-  ########################################
+    # service configures the server for service discovery.
+    # defined https://godoc.org/github.com/xmidt-org/webpa-common/service/servicecfg#Options
+    # this is required, consul or fixed must be used.
+    service:
+      # defaultScheme, used for the registered servers for communication.
+      # (Optional) defaults to https
+      defaultScheme: http
 
-  # service configures the server for service discovery.
-  # defined https://godoc.org/github.com/xmidt-org/webpa-common/service/servicecfg#Options
-  # this is required, consul or fixed must be used.
-  service:
-    # defaultScheme, used for the registered servers for communication.
-    # (Optional) defaults to https
-    defaultScheme: http
+      # vnodeCount used for consistent hash calculation github.com/billhathaway/consistentHash.
+      # number of virtual nodes. should be a prime number
+      # it is a tradeoff of memory and ~ log(N) speed versus how well the hash spreads
+      # (Optional) defaults to 211
+      vnodeCount: 211
 
-    # vnodeCount used for consistent hash calculation github.com/billhathaway/consistentHash.
-    # number of virtual nodes. should be a prime number
-    # it is a tradeoff of memory and ~ log(N) speed versus how well the hash spreads
-    # (Optional) defaults to 211
-    vnodeCount: 211
+      # disableFilter disables filtering.
+      # (Deprecated) does not do anything
+      # disableFilter: false
 
-    # disableFilter disables filtering.
-    # (Deprecated) does not do anything
-    # disableFilter: false
-
-    # fixed is the list of servers in the datacenter.
-    # (Optional) default to empty list
-    fixed:
-      - http://talaria:{{ .Values.talaria.address.port }}
+      # fixed is the list of servers in the datacenter.
+      # (Optional) default to empty list
+      fixed:
+        - http://talaria:{{ .Values.talaria.address.port }}
 kind: ConfigMap
 metadata:
   labels:

--- a/deploy/helm/talaria/values.yaml
+++ b/deploy/helm/talaria/values.yaml
@@ -1,0 +1,33 @@
+# Default values for xmitd-talaria.
+
+talaria:
+  # docker image used
+  image: xmidt/talaria
+  address:
+    host: ""
+    port: "6200"
+
+health:
+  address:
+    host: ""
+    port: "6201"
+
+pprof:
+  address:
+    host: ""
+    port: "6202"
+
+control:
+  address:
+    host: ""
+    port: "6203"
+
+metric:
+  address:
+    host: ""
+    port: "6204"  
+
+# Pull secret used when images are stored in a private repository
+# imagePullSecretName:
+
+


### PR DESCRIPTION
Helm chart for talaria. talaria.yaml was copied into a configMap. Addresses are configurable through Helm, see Values.yaml. More configuration options can be added as needed.

Pull requests on the way for scytale, petasos, caduceus.

Edit:
Scaling issue with replication not solved, yet.