### PR TITLE
Optimize Makefile for local testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ vendor:
 	$(GO) mod vendor
 
 .PHONY: build
-build: vendor
+build:
 	CGO_ENABLED=0 $(GO) build $(GOBUILDFLAGS)
 
 .PHONY: version
@@ -56,7 +56,7 @@ docker:
 		-f ./deploy/Dockerfile -t $(DOCKER_ORG)/$(APP):$(PROGVER) .
 
 .PHONY: local-docker
-local-docker:
+local-docker: vendor
 	docker build \
 		--build-arg VERSION=$(VERSION) \
 		--build-arg GITCOMMIT=$(GITCOMMIT) \

--- a/README.md
+++ b/README.md
@@ -101,10 +101,9 @@ make build
 
 The Makefile has the following options you may find helpful:
 * `make build`: builds the Talaria binary
-* `make docker`: builds a docker image for Talaria, making sure to get all
-   dependencies
-* `make local-docker`: builds a docker image for Talaria with the assumption
-   that the dependencies can be found already
+* `make docker`: fetches all dependencies from source and builds a 
+   Talaria docker image
+* `make local-docker`: vendors dependencies and builds a Talaria docker image (recommended for local testing)
 * `make test`: runs unit tests with coverage for Talaria
 * `make clean`: deletes previously-built binaries and object files
 
@@ -124,20 +123,27 @@ command.  Either option requires first getting the source code.
 
 See [Makefile](#Makefile) on specifics of how to build the image that way.
 
-For running a command, either you can run `docker build` after getting all
-dependencies, or make the command fetch the dependencies.  If you don't want to
-get the dependencies, run the following command:
+If you'd like to build it without make, follow these instructions based on your use case:
+
+- Local testing
 ```bash
+go mod vendor
 docker build -t talaria:local -f deploy/Dockerfile .
 ```
-If you want to get the dependencies then build, run the following commands:
+This allows you to test local changes to a dependency. For example, you can build 
+a Talaria image with the changes to an upcoming changes to [webpa-common](https://github.com/xmidt-org/webpa-common) by using the [replace](https://golang.org/ref/mod#go) directive in your go.mod file like so:
+```
+replace github.com/xmidt-org/webpa-common v1.10.8 => ../webpa-common
+```
+**Note:** if you omit `go mod vendor`, your build will fail as the path `../webpa-common` does not exist on the builder container.
+
+- Building a specific version
 ```bash
-GO111MODULE=on go mod vendor
-docker build -t talaria:local -f deploy/Dockerfile.local .
+git checkout v0.5.7 
+docker build -t talaria:v0.5.7 -f deploy/Dockerfile .
 ```
 
-For either command, if you want the tag to be a version instead of `local`,
-then replace `local` in the `docker build` command.
+**Additional Info:** If you'd like to stand up a XMiDT docker-compose cluster, read [this](https://github.com/xmidt-org/xmidt/blob/master/deploy/docker-compose/README.md).
 
 ### Kubernetes
 

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,6 +1,6 @@
 FROM docker.io/library/golang:1.14-alpine as builder
 
-MAINTAINER Jack Murdock <jack_murdock@comcast.com>
+LABEL MAINTAINER="Jack Murdock <jack_murdock@comcast.com>"
 
 WORKDIR /go/src/github.com/xmidt-org/talaria
 


### PR DESCRIPTION
These changes support the ability to build a local docker image using a local version of a dependency pointed to through the `replace` command in a go.mod file.

My proposal is to:
- remove the explicit call to vendor on the `build` make operation:
    - Starting with go1.14, the command automatically tries to use the vendor folder if it exists.
    - Compatible with the current workflow: pull all dependencies on build and test.
    - In the case a vendor folder is passed to the docker daemon, such folder doesn't get overwritten.
- Explicit call to vendor before making a local docker image
    - This covers the case in which a local dependency change needs to be passed as part of the vendor folder to the docker daemon but a call to vendor hasn't been made.