### PR TITLE
removed http scheme from address

### DIFF
--- a/deploy/packaging/talaria_spruce.yaml
+++ b/deploy/packaging/talaria_spruce.yaml
@@ -398,7 +398,7 @@ service:
           - (( concat "flavor=" flavor))
 
         # address tells consul where to contact the service.
-        address: (( concat "http://" server domain ))
+        address: (( grab $HOSTNAME || "talaria" ))
 
         # port tells consul what port to use to contact the service.  This is
         # used with the address for calls to this server.


### PR DESCRIPTION
Due to HTTP scheme in `consul.registrations.address` the rehasher was not working as expected. after removing the HTTP scheme it working fine.

Same is discussed in https://github.com/xmidt-org/xmidt/discussions/54
