### PR TITLE
Fix Talaria Stat Endpoint Accepting DELETE and other http verbs

### DIFF
--- a/primaryHandler.go
+++ b/primaryHandler.go
@@ -310,7 +310,7 @@ func NewPrimaryHandler(logger log.Logger, manager device.Manager, v *viper.Viper
 				Registry: manager,
 				Variable: "deviceID",
 			}),
-	)
+	).Methods("GET")
 
 	return r, nil
 }


### PR DESCRIPTION
- Updated the stat handler to only handle GET calls
- Stat handler no longer accepts other http methods
- Returns 405 Unsupported Method 

closes #202 