### PR TITLE
disable sat token checks for docker

### DIFF
--- a/.release/docker/talaria_spruce.yaml
+++ b/.release/docker/talaria_spruce.yaml
@@ -318,20 +318,21 @@ jwtValidator:
     #     - URI: (( grab $THEMIS_ENDPOINT || "http://themis:6500/keys/{keyID}" ))
     # Leeway: 0
 
-deviceAccessCheck:
-  type: (( grab $DEVICE_ACCESS_CHECK_TYPE ||  "enforce" ))
-  checks:
-    -
-      name: PartnerID
-      deviceCredentialPath: partner-id
-      op: contains
-      wrpCredentialPath: PartnerIDs
-      inversed: true
-    -
-      name: Trusted Device
-      deviceCredentialPath: trust
-      op: "gt"
-      inputValue: 999
+# disable SAT token checks since we are using basic auth
+# deviceAccessCheck:
+#   type: (( grab $DEVICE_ACCESS_CHECK_TYPE ||  "enforce" ))
+#   checks:
+#     -
+#       name: PartnerID
+#       deviceCredentialPath: partner-id
+#       op: contains
+#       wrpCredentialPath: PartnerIDs
+#       inversed: true
+#     -
+#       name: Trusted Device
+#       deviceCredentialPath: trust
+#       op: "gt"
+#       inputValue: 999
 
 ########################################
 #   Service Discovery Configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+
+## [v0.6.11]
+- Remove several unused build files and update the docker images to work. [#272](https://github.com/xmidt-org/talaria/pull/272)
 - Update configs and documentation for the introduction of OTLP in Candlelight [#282](https://github.com/xmidt-org/talaria/pull/282)
+- update bascule config in docker config [#295]https://github.com/
+xmidt-org/talaria/pull/295
+- remove/disable sat token checks from docker config [#297]https://github.com/xmidt-org/talaria/pull/297
 
 ## [v0.6.10]
 - Remove several unused build files and update the docker images to work. [#272](https://github.com/xmidt-org/talaria/pull/272)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,7 +175,8 @@ Switching to new build process
 ## [v0.1.1] Tue Mar 28 2017 Weston Schmidt - 0.1.1
 - initial creation
 
-[Unreleased]: https://github.com/xmidt-org/talaria/compare/v0.6.10...HEAD
+[Unreleased]: https://github.com/xmidt-org/talaria/compare/v0.6.11...HEAD
+[v0.6.11]: https://github.com/xmidt-org/talaria/compare/v0.6.10...v0.6.11
 [v0.6.10]: https://github.com/xmidt-org/talaria/compare/v0.6.9...v0.6.10
 [v0.6.9]: https://github.com/xmidt-org/talaria/compare/v0.6.8...v0.6.9
 [v0.6.8]: https://github.com/xmidt-org/talaria/compare/v0.6.7...v0.6.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [v0.6.11]
-- Remove several unused build files and update the docker images to work. [#272](https://github.com/xmidt-org/talaria/pull/272)
 - Update configs and documentation for the introduction of OTLP in Candlelight [#282](https://github.com/xmidt-org/talaria/pull/282)
 - update bascule config in docker config [#295]https://github.com/
 xmidt-org/talaria/pull/295

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [v0.6.11]
 - Update configs and documentation for the introduction of OTLP in Candlelight [#282](https://github.com/xmidt-org/talaria/pull/282)
-- update bascule config in docker config [#295]https://github.com/
-xmidt-org/talaria/pull/295
-- remove/disable sat token checks from docker config [#297]https://github.com/xmidt-org/talaria/pull/297
+- update bascule config in docker config [#295](https://github.com/
+xmidt-org/talaria/pull/295)
+- remove/disable sat token checks from docker config [#297](https://github.com/xmidt-org/talaria/pull/297)
 
 ## [v0.6.10]
 - Remove several unused build files and update the docker images to work. [#272](https://github.com/xmidt-org/talaria/pull/272)


### PR DESCRIPTION
remove sat token checks from the docker config since we are using basic auth for the local environment. 

