### PR TITLE
bumped workflow ci to 4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,11 @@ on:
 
 jobs:
   ci:
-    uses: xmidt-org/shared-go/.github/workflows/ci.yml@6dd1fab69f841fbea827a053e21fa83ea94774d9 # v3.0.0
+    uses: xmidt-org/shared-go/.github/workflows/ci.yml@d0737af7255c581ce3cc09b69b96ba16a5913b4e # v4.0.0
     with:
       copyright-skip:        true
       style-skip:            true
       release-type:          program
-      release-arch-arm64:    false
       release-docker:        true
       release-docker-latest: true
       release-docker-major:  true


### PR DESCRIPTION
talaria failing to build release.

looked at other repos and all are using workflow version 4.0 instead of 3.0.