### PR TITLE
patch: replace `genericDoReason` error reason with `unknown`

### DIFF
--- a/eventDispatcher.go
+++ b/eventDispatcher.go
@@ -314,9 +314,5 @@ func getDroppedMessageReason(err error) string {
 	}
 
 	// check for http `Do` related errors
-	if reason := getDoErrReason(err); reason != genericDoReason {
-		return reason
-	}
-
-	return unknown
+	return getDoErrReason(err)
 }

--- a/metrics.go
+++ b/metrics.go
@@ -70,7 +70,6 @@ const (
 	unroutableDestinationReason           = "unroutable_destination"
 	encodeErrReason                       = "encoding_err"
 	fullQueueReason                       = "full outbound queue"
-	genericDoReason                       = "do_error"
 	deadlineExceededReason                = "context_deadline_exceeded"
 	contextCanceledReason                 = "context_canceled"
 	addressErrReason                      = "address_error"

--- a/workerPool.go
+++ b/workerPool.go
@@ -144,5 +144,5 @@ func getDoErrReason(err error) string {
 		}
 	}
 
-	return genericDoReason
+	return unknown
 }


### PR DESCRIPTION
- `unknown` will be used for failures that don't fit existing categories