### PR TITLE
Add webpa-interface-label in metadata for online and offline events

### DIFF
--- a/deviceStatus.go
+++ b/deviceStatus.go
@@ -26,7 +26,8 @@ func statusMetadata(d device.Interface) map[string]string {
 		wrpmeta.Field{From: "webpa-last-reconnect-reason", To: "/last-reconnect-reason"},
 		wrpmeta.Field{From: "webpa-protocol", To: "/protocol"},
 		wrpmeta.Field{From: "webpa-interface-used", To: "/interface-used"},
-		wrpmeta.Field{From: "boot-time-retry-wait", To: "/boot-time-retry-wait"}).
+		wrpmeta.Field{From: "boot-time-retry-wait", To: "/boot-time-retry-wait"},
+		wrpmeta.Field{From: "webpa-interface-label", To: "/webpa-interface-label"}).
 		Set("/trust", strconv.Itoa(d.Metadata().TrustClaim())).
 		Build()
 


### PR DESCRIPTION
CPE will be sending `webpa-interface-label` in convey header which we need to handle in Talaria online event.
This label will help us to know whether the CPE is using primary network or SIM (from an extender) for WiFi.