### PR TITLE
remove from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,2 @@
 vendor
-talaria
 conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN     mkdir /etc/talaria/ \
 
 USER nobody
 
-#ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/entrypoint.sh"]
 
 EXPOSE 6100
 EXPOSE 6101

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN     mkdir /etc/talaria/ \
 
 USER nobody
 
-ENTRYPOINT ["/entrypoint.sh"]
+#ENTRYPOINT ["/entrypoint.sh"]
 
 EXPOSE 6100
 EXPOSE 6101


### PR DESCRIPTION
I don't know how this ever worked if the executable was ignored during the copy
