### PR TITLE
fix entrypoint

### DIFF
--- a/.release/docker/entrypoint.sh
+++ b/.release/docker/entrypoint.sh
@@ -1,6 +1,6 @@
+#!/usr/bin/env sh
 # SPDX-FileCopyrightText: 2022 Comcast Cable Communications Management, LLC
 # SPDX-License-Identifier: Apache-2.0
-#!/usr/bin/env sh
 set -e
 
 # check arguments for an option that would cause /talaria to stop

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,11 +45,11 @@ RUN     mkdir /etc/talaria/ \
 
 USER nobody
 
-#ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/entrypoint.sh"]
 
 EXPOSE 6100
 EXPOSE 6101
 EXPOSE 6102
 EXPOSE 6103
 
-ENTRYPOINT ["/talaria"]
+CMD ["/talaria"]


### PR DESCRIPTION
the shell directive has to be the first line of the script, it can't come after the license stuff or you get a very unhelpful error message