### PR TITLE
workflows: Bump shared-go/ci.yml to v4.8.9.  Build amd64 & arm64 releases.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,11 @@ on:
 
 jobs:
   ci:
-    uses: xmidt-org/shared-go/.github/workflows/ci.yml@59f5d322b0ee953245334530336f8e6503cacb65 # v4.4.27
+    uses: xmidt-org/shared-go/.github/workflows/ci.yml@39e0c06dc85a40778331da295d9cb3b70a9e2bb8 # v4.8.9
     with:
-      style-skip:            true
       release-type:          program
-      release-arch-arm64:    false
+      release-arch-amd64:    true
+      release-arch-arm64:    true
       release-docker:        true
       release-docker-latest: true
       release-docker-major:  true


### PR DESCRIPTION
## What's Changing
### shared-go/ci.yml
- Bump to v4.8.9.
- Build amd64 & arm64 releases.